### PR TITLE
feat: Extend the runtime

### DIFF
--- a/examples/extended.rs
+++ b/examples/extended.rs
@@ -7,7 +7,7 @@ fn main() {
     use tokenizer::*;
 
     let code = r#"
-        test("hey");
+        coolFunc(coolInstance.hey);
     "#;
 
     let tokenizer = Tokenizer::new(&code).wrap();
@@ -16,9 +16,26 @@ fn main() {
     scope.setup_globals();
 
     #[derive(Debug)]
-    struct Test;
+    struct CoolInstance;
 
-    impl RuntimeFunction for Test {
+    impl<'a> RuntimeInstance<'a> for CoolInstance {
+        fn get_prop(&self, prop: &str) -> LenarValue<'a> {
+            if prop == "hey" {
+                LenarValue::Bytes("hey".as_bytes())
+            } else {
+                LenarValue::Void
+            }
+        }
+
+        fn get_name<'s>(&self) -> &'s str {
+            "coolInstance"
+        }
+    }
+
+    #[derive(Debug)]
+    struct CoolFunc;
+
+    impl RuntimeFunction for CoolFunc {
         fn call<'s>(
             &mut self,
             mut args: Vec<LenarValue<'s>>,
@@ -31,11 +48,12 @@ fn main() {
         }
 
         fn get_name<'s>(&self) -> &'s str {
-            "test"
+            "coolFunc"
         }
     }
 
-    scope.add_global_function(Test);
+    scope.add_global_function(CoolFunc);
+    scope.add_global_instance(CoolInstance);
 
     Runtime::run_with_scope(&mut scope, &tokenizer);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,6 +529,15 @@ pub mod runtime {
     }
 
     impl<'a> Scope<'a> {
+        /// Add an instance to the global scope
+        pub fn add_global_instance(&mut self, val: impl RuntimeInstance<'a> + 'static) {
+            self.variables.insert(
+                val.get_name().to_owned(),
+                LenarValue::Instance(Rc::new(val)),
+            );
+        }
+
+        /// Add a function to the global scope
         pub fn add_global_function(&mut self, val: impl RuntimeFunction + 'static) {
             self.variables.insert(
                 val.get_name().to_owned(),
@@ -651,7 +660,7 @@ pub mod runtime {
                             stdout().write(s.as_bytes()).ok();
                         }
                         LenarValue::List(l) => {
-                            l.iter().for_each(|l| Self::write(l));
+                            l.iter().for_each(Self::write);
                         }
                         LenarValue::Void => {
                             stdout().write("Void".as_bytes()).ok();


### PR DESCRIPTION
```rust
let code = r#"
    coolFunc(coolInstance.hey);
"#;

let tokenizer = Tokenizer::new(&code).wrap();

let mut scope = Scope::default();
scope.setup_globals();

#[derive(Debug)]
struct CoolInstance;

impl<'a> RuntimeInstance<'a> for CoolInstance {
    fn get_prop(&self, prop: &str) -> LenarValue<'a> {
        if prop == "hey" {
            LenarValue::Bytes("hey".as_bytes())
        } else {
            LenarValue::Void
        }
    }

    fn get_name<'s>(&self) -> &'s str {
        "coolInstance"
    }
}

#[derive(Debug)]
struct CoolFunc;

impl RuntimeFunction for CoolFunc {
    fn call<'s>(
        &mut self,
        mut args: Vec<LenarValue<'s>>,
        _tokens_map: &'s Arc<Tokenizer>,
    ) -> LenarValue<'s> {
        let val = args.remove(0);
        let val = val.to_string();
        println!("{val}");
        LenarValue::Void
    }

    fn get_name<'s>(&self) -> &'s str {
        "coolFunc"
    }
}

scope.add_global_function(CoolFunc);
scope.add_global_instance(CoolInstance);

Runtime::run_with_scope(&mut scope, &tokenizer);
```